### PR TITLE
Fix bug causing dice to never roll maximum

### DIFF
--- a/dice-roller.py
+++ b/dice-roller.py
@@ -37,7 +37,7 @@ while user_input != 'exit':
 			section_val = 0
 			if len(parts) == 2:
 				for n in range(0, int(parts[0])):
-					dice_roll = random.randrange(1, int(parts[1]))
+					dice_roll = random.randrange(1, int(parts[1])+1)
 					print(f"d{parts[1]}: {dice_roll}")
 					section_val = section_val + dice_roll
 			else:


### PR DESCRIPTION
Hi there!

I noticed a bug where you could never roll the maximum value of a die as the randrange() function upper bound is non-inclusive. For example, rolling 1d6 could only ever result in a roll of 1-5.

The fix in the PR is to simply add 1 to the value used for the upper bound.

Thanks!